### PR TITLE
Fixed: Right margin of article in 1 column state

### DIFF
--- a/main.css
+++ b/main.css
@@ -1834,12 +1834,9 @@ i.material-icons {
 ***********************/
 @media only screen and (min-width: 1000px) {
   .articles.column_1 article {
-    flex-basis: calc(100% - 1rem);
-    width: calc(100% - 1rem);
+    flex-basis: 100%;
+    width: 100%;
     margin-right: Infinityrem;
-  }
-  .articles.column_1 article:nth-child(1n) {
-    margin-right: 0;
   }
   .articles.column_2 article {
     flex-basis: calc(50% - 1rem);


### PR DESCRIPTION
Right margin of article in 1 column state

before

<img width="1090" alt="2017-09-17 14 16 03" src="https://user-images.githubusercontent.com/11687509/30518266-c44e67e8-9bb3-11e7-805d-f4139fa45491.png">

after

<img width="1090" alt="2017-09-17 14 16 53" src="https://user-images.githubusercontent.com/11687509/30518267-c8a6743e-9bb3-11e7-9627-b91359a8a39e.png">

英語が苦手なので日本語でも。
2,3カラムの時はヘッダーの幅と記事の幅が同じですが、1カラムの状態で右側に少し余白ができるので修正してみました。